### PR TITLE
sigtstp is now ignored

### DIFF
--- a/sl.c
+++ b/sl.c
@@ -161,6 +161,7 @@ int main(int argc, char *argv[])
  signal(SIGINT, end_proc);
 #else
  signal(SIGINT, SIG_IGN);
+ signal(SIGTSTP, SIG_IGN);
  PASSNUM = (int)(drand48() * 20.0) + 10;
  if (drand48() > 0.5) {
   ONEDIREC = 1;


### PR DESCRIPTION
Closes #1. It is vital that the user cannot escape their punishment for being so bad at typing ls.